### PR TITLE
Add jvm tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/src/main/java/me/worric/databindingplayground/repository/CoffeeGeneratorImpl.java
+++ b/app/src/main/java/me/worric/databindingplayground/repository/CoffeeGeneratorImpl.java
@@ -19,6 +19,10 @@ public class CoffeeGeneratorImpl implements CoffeeGenerator {
         mRandom = new Random();
     }
 
+    public CoffeeGeneratorImpl(Random random) {
+        mRandom = random;
+    }
+
     @Override
     public Coffee generateCoffee() {
         String name = mNames[getRandomNumberBoundedByArrayLength()];

--- a/app/src/test/java/me/worric/databindingplayground/repository/CoffeeGeneratorImplTest.java
+++ b/app/src/test/java/me/worric/databindingplayground/repository/CoffeeGeneratorImplTest.java
@@ -1,0 +1,43 @@
+package me.worric.databindingplayground.repository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Random;
+
+import me.worric.domain.model.Coffee;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CoffeeGeneratorImplTest {
+
+    @Mock
+    private Random mRandom;
+    private CoffeeGenerator mGenerator;
+
+    @Before
+    public void setUp() {
+        mGenerator = new CoffeeGeneratorImpl(mRandom);
+    }
+
+    @Test
+    public void onGenerateCoffee_returnsCorrectCoffee() {
+        String expectedName = "Heartbreaker";
+        int randomIntValue = 2;
+        when(mRandom.nextInt(anyInt())).thenReturn(randomIntValue);
+
+        Coffee generatedCoffee = mGenerator.generateCoffee();
+
+        assertThat(generatedCoffee.getName(), is(equalTo(expectedName)));
+        assertThat(generatedCoffee.getNumber(), is(equalTo(randomIntValue)));
+    }
+
+}

--- a/app/src/test/java/me/worric/databindingplayground/repository/CoffeeRepositoryImplTest.java
+++ b/app/src/test/java/me/worric/databindingplayground/repository/CoffeeRepositoryImplTest.java
@@ -2,34 +2,40 @@ package me.worric.databindingplayground.repository;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import me.worric.domain.model.Coffee;
 import me.worric.domain.repository.CoffeeRepository;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CoffeeRepositoryImplTest {
 
+    @Mock
+    private CoffeeGenerator mGenerator;
     private CoffeeRepository mRepository;
-    private final String[] mNames = new String[] {
-            "Teh Goodness",
-            "Teh OTHER goodness",
-            "Heartbreaker",
-            "Mister McStuffins"
-    };
 
     @Before
     public void setUp() {
-        mRepository = new CoffeeRepositoryImpl(new CoffeeGeneratorImpl());
+        mRepository = new CoffeeRepositoryImpl(mGenerator);
     }
 
     @Test
-    public void generatedCoffee_hasCorrectValues() {
-        Coffee coffee = mRepository.getOne();
+    public void onGetOne_correctlyReturnsGeneratedCoffee() {
+        final String coffeeName = "test";
+        final int coffeeNumber = 10;
+        when(mGenerator.generateCoffee())
+                .thenReturn(new Coffee(coffeeName, coffeeNumber));
 
-        assertThat(coffee.getName(), isIn(mNames));
-        assertThat("Larger than 0 and lower than 100", coffee.getNumber() > 0 && coffee.getNumber() < 100);
+        Coffee fetchedCoffee = mRepository.getOne();
+
+        assertThat(fetchedCoffee.getName(), is(coffeeName));
+        assertThat(fetchedCoffee.getNumber(), is(coffeeNumber));
     }
 
 }

--- a/app/src/test/java/me/worric/databindingplayground/repository/CoffeeRepositoryImplTest.java
+++ b/app/src/test/java/me/worric/databindingplayground/repository/CoffeeRepositoryImplTest.java
@@ -10,7 +10,9 @@ import me.worric.domain.model.Coffee;
 import me.worric.domain.repository.CoffeeRepository;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -34,8 +36,9 @@ public class CoffeeRepositoryImplTest {
 
         Coffee fetchedCoffee = mRepository.getOne();
 
-        assertThat(fetchedCoffee.getName(), is(coffeeName));
-        assertThat(fetchedCoffee.getNumber(), is(coffeeNumber));
+        verify(mGenerator).generateCoffee();
+        assertThat(fetchedCoffee.getName(), is(equalTo(coffeeName)));
+        assertThat(fetchedCoffee.getNumber(), is(equalTo(coffeeNumber)));
     }
 
 }


### PR DESCRIPTION
This PR adds tests of the `CoffeeRepositoryImpl` and `CoffeeGeneratorImpl` classes. It also adds an overloaded constructor to `CoffeeGeneratorImpl` in order to allow for injection of a mock `Random`.